### PR TITLE
ISSUE-1: Node Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ They will not be included in the production build so you can use them for things
 
 ## Available Scripts
 
+To correct error "0308010C:digital envelope routines::unsupported",
+
+The Correct (safe) Solution
+Use an up-to-date version of Node.js, and also use packages that are up-to-date with security fixes.
+
+For many people, the following command will fix the issue:
+
+### `npm audit fix --force`
+
+
 In the project directory, you can run:
 
 ### `npm start`


### PR DESCRIPTION
Updated readme to include solution to below:

Reason For The Error
In Node.js v17, the Node.js developers closed a security hole in the SSL provider. This fix was a breaking change that corresponded with similar breaking changes in the SSL packages in NPM. When you attempt to use SSL in Node.js v17 or later without also upgrading those SSL packages in your package.json, then you will see this error.

The Correct (safe) Solution
Use an up-to-date version of Node.js, and also use packages that are up-to-date with security fixes.

For many people, the following command will fix the issue:

npm audit fix --force
However, be aware that, for complex builds, the above command will pull in breaking security fixes that can potentially break your build.
